### PR TITLE
Prepare 0.2.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Read changlog
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          version: ${{ github.ref_name }}
+          path: docs/changelog.md
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body: ${{ steps.changelog_reader.outputs.changes }}
+          name: 'v${{ github.ref_name }}'

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1] - 28.04.2022
+### Added
+- Add relations for user identification
+- Add atomic and non-atomic action classes
+
+### Changed
+- Fix scsi files for build
+- Fix flow of setting system idtf for files
+
+### Removed
+- Remove duplicated nodes


### PR DESCRIPTION
Added release workflow in CI. Tested [here](https://github.com/KovalM/ims.ostis.kb/releases/tag/0.2.1). After merge this PR we will need just create tag 0.2.1 for release 