### PR TITLE
feat: add standard submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "ostis-standard"]
+	path = ostis-standard
+	url = https://github.com/ostis-ai/ostis-standard
+	branch = translated_scs


### PR DESCRIPTION
Нужно для того, чтобы транслированные scs-файлы базы знаний стандарта попали в базу знаний ims.ostis.kb. Плюс там же можно разрабатывать новые версии стандарта